### PR TITLE
ht: Add Mutex to protect test from race conditions

### DIFF
--- a/ht/suite.go
+++ b/ht/suite.go
@@ -42,7 +42,9 @@ func (s *Collection) ExecuteConcurrent(maxConcurrent int, jar *cookiejar.Jar) er
 	}
 	for _, test := range s.Tests {
 		if jar != nil {
+			test.mu.Lock()
 			test.Jar = jar
+			test.mu.Unlock()
 		}
 		c <- test
 	}


### PR DESCRIPTION
Compilation would fail due to the concurrent map access. This mutex
manages the access to the all fields when one test runs multiple
times within a ht.Collection and in parallel.

There were in total 40 race conditions.

Fixes also some typos ;-)